### PR TITLE
Versionupdate

### DIFF
--- a/start-wordpress.sh
+++ b/start-wordpress.sh
@@ -24,12 +24,10 @@ echo -n "Enter DB password [ENTER]: "
 read -s db_pass
 
 echo -e "\n\nCreating database 'wordpress' on MySQL server..."
-echo "create database wordpress" | mysql --host=$db_url --user=$db_user --password=$db_pass
-echo "Database created!"
+echo "create database wordpress" | mysql --host=$db_url --user=$db_user --password=$db_pass && echo "Database created!"
 
 echo "Starting Wordpress server.."
 sudo docker stop wordpress &>/dev/null | true
 sudo docker rm wordpress &>/dev/null | true
-sudo docker run -d --name wordpress -e WORDPRESS_DB_HOST=$db_url -e WORDPRESS_DB_USER=$db_user -e WORDPRESS_DB_PASSWORD=$db_pass -e WORDPRESS_DB_NAME=wordpress -e WORDPRESS_TABLE_PREFIX=wp_ --network host wordpress
-
+sudo docker run -d --name wordpress -e WORDPRESS_DB_HOST=$db_url -e WORDPRESS_DB_USER=$db_user -e WORDPRESS_DB_PASSWORD=$db_pass -e WORDPRESS_DB_NAME=wordpress -e WORDPRESS_TABLE_PREFIX=wp_ --network host wordpress && \
 echo "Access Wordpress via http://$PUB_IP"

--- a/start-wordpress.sh
+++ b/start-wordpress.sh
@@ -6,13 +6,13 @@ sudo apt-get -y install apt-transport-https ca-certificates curl software-proper
 
 # Add apt repos
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-sudo add-apt-repository \
+sudo --yes add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
 
 # Install Docker
-sudo apt-get -y install docker-ce mysql-client-core-5.7
+sudo apt-get -y install docker-ce mariadb-client-core-10.6
 
 echo  -e -n "\n\nEnter DB URL [ENTER]: "
 read db_url


### PR DESCRIPTION
As Ubuntu 18.04 reaches its end of support on April 2023, we decided to upgrade the OS in the Training to Ubuntu 22.04.
For this to work the mysql-client dependency must be fixed, as this is for for the 22.04 the mariadb client with at least version 10.6

Furthermore the successmessages are now only displayed on case of a success return codes.
A couple of training participants were confused as there were on the one hand errors in the console and on the other hand successmessages.